### PR TITLE
feat(workspace): implement alternating linked list function

### DIFF
--- a/Week_1/Day_1/solutions/Go/.idea/Go.iml
+++ b/Week_1/Day_1/solutions/Go/.idea/Go.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/Week_1/Day_1/solutions/Go/go.mod
+++ b/Week_1/Day_1/solutions/Go/go.mod
@@ -1,0 +1,3 @@
+module Go
+
+go 1.23

--- a/Week_1/Day_5/solutions/main.go
+++ b/Week_1/Day_5/solutions/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Node struct {
+	data int
+	next *Node
+}
+
+type Context struct {
+	first  *Node
+	second *Node
+}
+
+func alternatingLinkedList(head *Node) (*Context, error) {
+	if head == nil || head.next == nil {
+		return nil, errors.New("list must contain at least two nodes")
+	}
+
+	var firstHead, secondHead, firstTail, secondTail *Node
+	var isFirst = true
+	var current = head
+
+	for current != nil {
+		nextNode := current.next
+		current.next = nil
+
+		if isFirst {
+			if firstHead == nil {
+				firstHead = current
+				firstTail = current
+			} else {
+				firstTail.next = current
+				firstTail = current
+			}
+		} else {
+			if secondHead == nil {
+				secondHead = current
+				secondTail = current
+			} else {
+				secondTail.next = current
+				secondTail = current
+			}
+		}
+
+		current = nextNode
+		isFirst = !isFirst
+	}
+	return &Context{first: firstHead, second: secondHead}, nil
+}
+
+func ArrayToLinkedList(arr []int) *Node {
+	var head, tail *Node
+
+	for _, val := range arr {
+		newNode := &Node{data: val}
+		if head == nil {
+			head = newNode
+			tail = newNode
+		} else {
+			tail.next = newNode
+			tail = newNode
+		}
+	}
+
+	return head
+}
+
+func PrintLinkedList(head *Node) {
+	current := head
+	for current != nil {
+		fmt.Printf("%d -> ", current.data)
+		current = current.next
+	}
+	fmt.Println("nil")
+}
+
+func main() {
+
+	var arr = []int{1, 2, 3, 4, 5}
+	list := ArrayToLinkedList(arr)
+	PrintLinkedList(list)
+
+	result, err := alternatingLinkedList(list)
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("First List:")
+	PrintLinkedList(result.first)
+
+	fmt.Println("Second List:")
+	PrintLinkedList(result.second)
+}


### PR DESCRIPTION
This commit introduces a function to split a linked list into two alternating lists. The function takes a linked list as input and returns a context object containing the heads of the two resulting lists.

This improves code organization and provides a reusable function for splitting linked lists.